### PR TITLE
switch to using a monospace font

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
         }
         body {
             padding-bottom: 10px;
+            font-family: monospace;
         }
     </style>
 </head>


### PR DESCRIPTION
Some websites like to hide ASCII art in their comments. However, this doesn't appear correctly in the extension, as it uses the plain font:
![vivaldi_5ZxFAz1plU](https://github.com/user-attachments/assets/cb3cc9ef-404f-4793-95fa-f608451ed3fd)
This is how it appears in the page source:
![vivaldi_FQedpg8ze0](https://github.com/user-attachments/assets/7e85fec3-18f8-4d17-afb6-fcc0298715ae)
Not only that, but it does kind of just look cool.

This change only changes the font, it doesn't fix the bug where multiple spaces are removed